### PR TITLE
Revert Travis to correct JRuby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ bundler_args: --without documentation production
 rvm:
   - 1.9.3
   - 2.0.0
-  - jruby-19mode-1.7.4
+  - jruby-19mode
   - rbx-19mode
 matrix:
   allow_failures:


### PR DESCRIPTION
Currently Travis runs the JRuby with JRuby version 1.7.3, allthough version 1.7.4 is the current version.

Because Nokogiri 1.6.0 doesn't install correctly on JRuby 1.7.3 I added the 1.7.4 flag (`jruby-19mode-1.7.4`) to the `.travis.yml`.

It needs to be reverted back to `jruby-19mode` after Travis runs on JRuby 1.7.4 by default.

See [this issue](https://github.com/travis-ci/travis-ci/issues/1153) for details.
