### PR TITLE
Reference file in zip multiple times

### DIFF
--- a/lib/executrix.rb
+++ b/lib/executrix.rb
@@ -62,7 +62,8 @@ module Executrix
         zip_filename = "#{Dir.tmpdir}/#{tmp_filename}"
         Zip::File.open(zip_filename, Zip::File::CREATE) do |zipfile|
           Executrix::Helper.transform_values!(records, attachment_keys) do |path|
-            zipfile.add(Executrix::Helper.absolute_to_relative_path(path, ''), path)
+            relative_path = Executrix::Helper.absolute_to_relative_path(path, '')
+            zipfile.add(relative_path, path) rescue Zip::ZipEntryExistsError
           end
           tmp_filename = Dir::Tmpname.make_tmpname('request', '.txt')
           request_filename = "#{Dir.tmpdir}/#{tmp_filename}"


### PR DESCRIPTION
When a file is referenced multiple times, executrix tries to add this file to zip archive multiple times. In that case [rubyzip](https://github.com/rubyzip/rubyzip) throws an `ZipEntryExistsError`.
