### PR TITLE
add support for multiple pages of results for very large queries

### DIFF
--- a/lib/executrix/batch.rb
+++ b/lib/executrix/batch.rb
@@ -39,10 +39,7 @@ module Executrix
     # results returned from Salesforce can be a single page id, or an array of ids.
     # if it's an array of ids, we will fetch the results from each, and concatenate them.
     def results
-      result_ids = query_result_id
-      result_ids = Array(result_ids) unless result_ids.respond_to?(:each)
-
-      result_ids.map do |result_id|
+      Array(query_result_id).map do |result_id|
         @connection.query_batch_result_data(@job_id, @batch_id, result_id)
       end.flatten
     end

--- a/spec/lib/executrix/batch_spec.rb
+++ b/spec/lib/executrix/batch_spec.rb
@@ -82,16 +82,16 @@ describe Executrix::Batch do
       let(:single_result) {{:Id=>"M75200000001Vgt", :name=>"Joe"}}
 
       it 'returns the results' do
-        connection.should_receive(:query_batch_result_id).
+        expect(connection).to receive(:query_batch_result_id).
           with(job_id, batch_id).
           and_return({:result => result_id})
 
-        connection.should_receive(:query_batch_result_data).
+        expect(connection).to receive(:query_batch_result_data).
           once.
           with(job_id, batch_id, result_id).
           and_return(single_result)
 
-        subject.results.should == [single_result]
+        expect(subject.results).to eq([single_result])
       end
     end
 
@@ -102,26 +102,26 @@ describe Executrix::Batch do
         {:Id=>"AAA11125", :name=>"Mike"}]}
 
       it 'returns concatenated results' do
-        connection.should_receive(:query_batch_result_id).
+        expect(connection).to receive(:query_batch_result_id).
           with(job_id, batch_id).
           and_return({:result => result_ids})
 
-        connection.should_receive(:query_batch_result_data).
+        expect(connection).to receive(:query_batch_result_data).
           ordered.
           with(job_id, batch_id, result_ids[0]).
           and_return(multiple_results[0])
 
-        connection.should_receive(:query_batch_result_data).
+        expect(connection).to receive(:query_batch_result_data).
           ordered.
           with(job_id, batch_id, result_ids[1]).
           and_return(multiple_results[1])
 
-        connection.should_receive(:query_batch_result_data).
+        expect(connection).to receive(:query_batch_result_data).
           ordered.
           with(job_id, batch_id, result_ids[2]).
           and_return(multiple_results[2])
 
-        subject.results.should == multiple_results
+        expect(subject.results).to eq(multiple_results)
       end
     end
   end

--- a/spec/lib/executrix/connection_spec.rb
+++ b/spec/lib/executrix/connection_spec.rb
@@ -73,22 +73,22 @@ describe Executrix::Connection do
     context 'with a single page of results' do
       let(:single_result) {{:result=>"M75200000001Vgt", :@xmlns=>"http://www.force.com/2009/06/asyncapi/dataload"}}
       it 'returns the result_id as a string' do
-        Executrix::Http.should_receive(:query_batch_result_id).
+        expect(Executrix::Http).to receive(:query_batch_result_id).
           with(nil, nil, job_id, batch_id, nil).
           and_return(single_result)
 
-        subject.query_batch_result_id("12345", "67890").should == single_result
+        expect(subject.query_batch_result_id(job_id, batch_id)).to eq(single_result)
       end
     end
 
     context 'with an array of page of results' do
       let(:multiple_result) {{:result=>["752M00000001Vgt", "752M00000001Vgy"], :@xmlns=>"http://www.force.com/2009/06/asyncapi/dataload"}}
       it 'returns the resu lt_id as a string' do
-        Executrix::Http.should_receive(:query_batch_result_id).
+        expect(Executrix::Http).to receive(:query_batch_result_id).
           with(nil, nil, job_id, batch_id, nil).
           and_return(multiple_result)
 
-        subject.query_batch_result_id("12345", "67890").should == multiple_result
+        expect(subject.query_batch_result_id(job_id, batch_id)).to eq(multiple_result)
       end
     end
   end


### PR DESCRIPTION
First, thanks for re-releasing this gem under new management.  I love how easy this is to use now.  Automatically polling the batch status is just awesome.

for bulk_api queries with a very large number of results (maybe...more than 2 million?) , Salesforce may return an array of result_ids, instead of a single result_id.  This will handle both cases.  If there are multiple result_ids, we will iterate through them and query the results for each.  Then we'll concatenate them into a single flattened array of results.
