### PR TITLE
Sets null value for fields in SF

### DIFF
--- a/lib/executrix/helper.rb
+++ b/lib/executrix/helper.rb
@@ -18,7 +18,11 @@ module Executrix
       records.each do |hash|
         row = CSV::Row.new([],[],false)
         to_store = hash.inject({}) do |h, (k, v)|
-          h[k] = v.class == Array ? v.join(';') : v
+          if v == nil || v == '' || v == []
+            h[k] = '#N/A'
+          else
+            h[k] = v.class == Array ? v.join(';') : v
+          end
           h
         end
         row << to_store

--- a/spec/lib/executrix/helper_spec.rb
+++ b/spec/lib/executrix/helper_spec.rb
@@ -60,6 +60,18 @@ describe Executrix::Helper do
       "\"A second Title\",\"A second name\"\n"
       expect(described_class.records_to_csv(input)).to eq(expected_csv)
     end
+
+    it 'correctly converts empty arrays, nil values and blank strings to #N/A' do
+      input = [
+        {'Title' => nil, 'Picklist' => ['Several', 'Values']},
+        {'Title' => '', 'Picklist' => []},
+      ]
+
+      expected_csv = "\"Title\",\"Picklist\"\n" \
+        "\"#N/A\",\"Several;Values\"\n" \
+        "\"#N/A\",\"#N/A\"\n"
+      expect(described_class.records_to_csv(input)).to eq(expected_csv)
+    end
   end
 
   describe '.fetch_instance_from_server_url' do


### PR DESCRIPTION
Solves https://github.com/propertybase/executrix/issues/21

According to documentation, to set field value to null in Salesforce the supplied value should be #N/A
https://www.salesforce.com/us/developer/docs/api_asynch/Content/datafiles_csv_valid_record_rows.htm#kanchor46
